### PR TITLE
Added support for VMware DVS

### DIFF
--- a/gbpservice/neutron/plugins/ml2/drivers/grouppolicy/apic/driver.py
+++ b/gbpservice/neutron/plugins/ml2/drivers/grouppolicy/apic/driver.py
@@ -26,6 +26,10 @@ from gbpservice.neutron.services.grouppolicy.drivers.cisco.apic import (
 
 LOG = log.getLogger(__name__)
 
+# TODO(tbachman) Find a good home for these
+AGENT_TYPE_DVS = 'DVS agent'
+VIF_TYPE_DVS = 'dvs'
+
 
 class APICMechanismGBPDriver(mech_agent.AgentMechanismDriverBase):
 
@@ -36,15 +40,60 @@ class APICMechanismGBPDriver(mech_agent.AgentMechanismDriverBase):
         super(APICMechanismGBPDriver, self).__init__(
             ofcst.AGENT_TYPE_OPFLEX_OVS)
 
+    def _is_dvs_vif_type(self, context, agent):
+        """Return if this port is a DVS vif
+
+           We need to bind the port as a DVS VIF type
+           when the port belongs to nova, and when there's
+           an OpFlex agent on that (compute) host that's told
+           us it's supporting a VMware hypervisor.
+        """
+        port = context.current
+        if port['device_owner'] == 'compute:nova':
+            hv_type = agent['configurations'].get('hypervisor_type', None)
+            if hv_type and hv_type == acst.HYPERVISOR_VCENTER:
+                return True
+        return False
+
+    def _get_dvs_vif_details(self, context):
+        """Populate VIF details for DVS VIFs.
+
+           For DVS VIFs, provide the portgroup along
+           with the security groups setting
+        """
+
+        tenant_id = context.current.get('tenant_id')
+        network_id = context.current.get('network_id')
+        vif_details = ({portbindings.CAP_PORT_FILTER:
+                        self.vif_details[portbindings.CAP_PORT_FILTER]})
+        if tenant_id and network_id:
+            network = self.apic_gbp._get_network(context._plugin_context,
+                                                 network_id)
+            project_name = self.apic_gbp.name_mapper.tenant(context.current)
+            profile = (self.apic_gbp.apic_manager.
+                apic_config.apic_app_profile_name)
+            # networks are named using the name of the Policy Target
+            # Group prepended iwth "l2p_". However, the portgroup just
+            # uses the Policy Target Group name
+            network_name = network['name'][4:]
+            vif_details['dvs_port_group'] = (str(project_name) +
+                                             '|' + profile +
+                                             '|' + network_name)
+        return vif_details
+
     def try_to_bind_segment_for_agent(self, context, segment, agent):
-        if self.check_segment_for_agent(segment, agent):
-            context.set_binding(
-                segment[api.ID], self.vif_type, self.vif_details)
+        if self._check_segment_for_agent(segment, agent):
+            vif_type = self.vif_type
+            vif_details = self.vif_details
+            if self._is_dvs_vif_type(context, agent)
+                vif_type = VIF_TYPE_DVS
+                vif_details = self._get_dvs_vif_details(context)
+            context.set_binding(segment[api.ID], vif_type, vif_details)
             return True
         else:
             return False
 
-    def check_segment_for_agent(self, segment, agent):
+    def _check_segment_for_agent(self, segment, agent):
         network_type = segment[api.NETWORK_TYPE]
         if network_type == ofcst.TYPE_OPFLEX:
             opflex_mappings = agent['configurations'].get('opflex_networks')

--- a/gbpservice/neutron/tests/unit/services/grouppolicy/test_apic_mapping.py
+++ b/gbpservice/neutron/tests/unit/services/grouppolicy/test_apic_mapping.py
@@ -33,6 +33,7 @@ from oslo_config import cfg
 
 sys.modules["apicapi"] = mock.Mock()
 
+from gbpservice.neutron.plugins.ml2.drivers.grouppolicy.apic import driver
 from gbpservice.neutron.services.grouppolicy import (
     group_policy_context as p_context)
 from gbpservice.neutron.services.grouppolicy import config
@@ -58,6 +59,12 @@ AGENT_CONF = {'alive': True, 'binary': 'somebinary',
               'topic': 'sometopic', 'agent_type': AGENT_TYPE,
               'configurations': {'opflex_networks': None,
                                  'bridge_mappings': {'physnet1': 'br-eth1'}}}
+AGENT_CONF_DVS = {'alive': True, 'binary': 'somebinary',
+                  'topic': 'sometopic', 'agent_type': AGENT_TYPE,
+                  'configurations':
+                      {'hypervisor_type': driver.HYPERVISOR_VCENTER,
+                       'opflex_networks': None,
+                       'bridge_mappings': {'physnet1': 'br-eth1'}}}
 
 
 def echo(context, string, prefix=''):
@@ -98,9 +105,6 @@ class ApicMappingTestCase(
         }
         mock.patch('gbpservice.neutron.services.grouppolicy.drivers.cisco.'
                    'apic.apic_mapping.ApicMappingDriver._setup_rpc').start()
-        host_agents = mock.patch('neutron.plugins.ml2.driver_context.'
-                                 'PortContext.host_agents').start()
-        host_agents.return_value = [self.agent_conf]
         nova_client = mock.patch(
             'gbpservice.neutron.services.grouppolicy.drivers.cisco.'
             'apic.nova_client.NovaClient.get_server').start()
@@ -192,7 +196,15 @@ class ApicMappingTestCase(
             shared=shared)['policy_rule']
 
     def _bind_port_to_host(self, port_id, host):
-        data = {'port': {'binding:host_id': host, 'device_owner': 'compute:',
+        data = {'port': {'binding:host_id': host,
+                         'device_owner': 'compute:nova',
+                         'device_id': 'someid'}}
+        return super(ApicMappingTestCase, self)._bind_port_to_host(
+            port_id, host, data=data)
+
+    def _bind_net_port_to_host(self, port_id, host):
+        data = {'port': {'binding:host_id': host,
+                         'device_owner': 'network:dhcp',
                          'device_id': 'someid'}}
         return super(ApicMappingTestCase, self)._bind_port_to_host(
             port_id, host, data=data)
@@ -802,6 +814,116 @@ class TestPolicyTarget(ApicMappingTestCase):
         self.assertEqual(2, len(entries))
         self.assertEqual('1.1.1.1', entries[0].ha_ip_address)
         self.assertEqual('1.1.1.1', entries[1].ha_ip_address)
+
+
+class TestPolicyTargetDvs(ApicMappingTestCase):
+
+    # TODO(tbachman) I couldn't figure out how to get the right
+    # reference for the app_profile_name (I think it has to do
+    # with getting the reference at the right point -- maybe
+    # needs to happen at import time?). With that, we can verify
+    # that the dvs_port_group name is properly constructed
+
+    def test_bind_port_dvs(self):
+        self.agent_conf = AGENT_CONF_DVS
+        ptg = self.create_policy_target_group(
+            name="ptg1")['policy_target_group']
+        subnet = self._get_object('subnets', ptg['subnets'][0], self.api)
+        with self.port(subnet=subnet) as port:
+            newp1 = self._bind_port_to_host(port['port']['id'], 'h1')
+            pt = self.create_policy_target(
+                policy_target_group_id=ptg['id'], port_id=port['port']['id'])
+            self.new_delete_request(
+                'policy_targets', pt['policy_target']['id'],
+                self.fmt).get_response(self.ext_api)
+            self.assertTrue(self.driver.notifier.port_update.called)
+            vif_det = newp1['port']['binding:vif_details']
+            self.assertIsNotNone(vif_det.get('dvs_port_group', None))
+
+    def test_bind_port_dvs_with_opflex_diff_hosts(self):
+        self.agent_conf = AGENT_CONF_DVS
+        ptg = self.create_policy_target_group(
+            name="ptg1")['policy_target_group']
+        subnet = self._get_object('subnets', ptg['subnets'][0], self.api)
+        with self.port(subnet=subnet) as port1:
+            newp1 = self._bind_port_to_host(port1['port']['id'], 'h1')
+            pt1 = self.create_policy_target(
+                policy_target_group_id=ptg['id'], port_id=port1['port']['id'])
+            self.new_delete_request(
+                'policy_targets', pt1['policy_target']['id'],
+                self.fmt).get_response(self.ext_api)
+            self.assertTrue(self.driver.notifier.port_update.called)
+            vif_det = newp1['port']['binding:vif_details']
+            self.assertIsNotNone(vif_det.get('dvs_port_group', None))
+
+            with self.port(subnet=subnet) as port2:
+                self.agent_conf = AGENT_CONF
+                newp2 = self._bind_port_to_host(port2['port']['id'], 'h2')
+                pt2 = self.create_policy_target(
+                    policy_target_group_id=ptg['id'],
+                    port_id=port2['port']['id'])
+                self.new_delete_request(
+                    'policy_targets', pt2['policy_target']['id'],
+                    self.fmt).get_response(self.ext_api)
+                self.assertTrue(self.driver.notifier.port_update.called)
+                vif_det = newp2['port']['binding:vif_details']
+                self.assertIsNone(vif_det.get('dvs_port_group', None))
+
+    def test_bind_ports_opflex_same_host(self):
+        ptg = self.create_policy_target_group(
+            name="ptg1")['policy_target_group']
+        subnet = self._get_object('subnets', ptg['subnets'][0], self.api)
+        with self.port(subnet=subnet) as port1:
+            newp1 = self._bind_port_to_host(port1['port']['id'], 'h1')
+            pt1 = self.create_policy_target(
+                policy_target_group_id=ptg['id'], port_id=port1['port']['id'])
+            self.new_delete_request(
+                'policy_targets', pt1['policy_target']['id'],
+                self.fmt).get_response(self.ext_api)
+            self.assertTrue(self.driver.notifier.port_update.called)
+            vif_det = newp1['port']['binding:vif_details']
+            self.assertIsNone(vif_det.get('dvs_port_group', None))
+
+            with self.port(subnet=subnet) as port2:
+                newp2 = self._bind_net_port_to_host(port2['port']['id'], 'h1')
+                pt2 = self.create_policy_target(
+                    policy_target_group_id=ptg['id'],
+                    port_id=port2['port']['id'])
+                self.new_delete_request(
+                    'policy_targets', pt2['policy_target']['id'],
+                    self.fmt).get_response(self.ext_api)
+                self.assertTrue(self.driver.notifier.port_update.called)
+                vif_det = newp2['port']['binding:vif_details']
+                self.assertIsNone(vif_det.get('dvs_port_group', None))
+
+    def test_bind_ports_dvs_with_opflex_same_host(self):
+        self.agent_conf = AGENT_CONF_DVS
+        ptg = self.create_policy_target_group(
+            name="ptg1")['policy_target_group']
+        subnet = self._get_object('subnets', ptg['subnets'][0], self.api)
+        with self.port(subnet=subnet) as port1:
+            newp1 = self._bind_port_to_host(port1['port']['id'], 'h1')
+            pt1 = self.create_policy_target(
+                policy_target_group_id=ptg['id'], port_id=port1['port']['id'])
+            self.new_delete_request(
+                'policy_targets', pt1['policy_target']['id'],
+                self.fmt).get_response(self.ext_api)
+            self.assertTrue(self.driver.notifier.port_update.called)
+            vif_det = newp1['port']['binding:vif_details']
+            self.assertIsNotNone(vif_det.get('dvs_port_group', None))
+
+            self.agent_conf = AGENT_CONF
+            with self.port(subnet=subnet) as port2:
+                newp2 = self._bind_net_port_to_host(port2['port']['id'], 'h1')
+                pt2 = self.create_policy_target(
+                    policy_target_group_id=ptg['id'],
+                    port_id=port2['port']['id'])
+                self.new_delete_request(
+                    'policy_targets', pt2['policy_target']['id'],
+                    self.fmt).get_response(self.ext_api)
+                self.assertTrue(self.driver.notifier.port_update.called)
+                vif_det = newp2['port']['binding:vif_details']
+                self.assertIsNone(vif_det.get('dvs_port_group', None))
 
 
 class TestPolicyTargetGroup(ApicMappingTestCase):


### PR DESCRIPTION
This adds support for port binding DVS VIF types. The
port group that the port belongs to is passed in the
VIF binding details, so that Nova can use it to bring
up the instance.