### PR TITLE
Fixed _query_endpoint_haip_owned_ip_info SQL Query 

### DIFF
--- a/gbpservice/neutron/plugins/ml2plus/drivers/apic_aim/rpc.py
+++ b/gbpservice/neutron/plugins/ml2plus/drivers/apic_aim/rpc.py
@@ -635,12 +635,12 @@ class ApicRpcHandlerMixin(object):
         query += lambda q: q.outerjoin(
             models_v2.IPAllocation,
             models_v2.IPAllocation.ip_address ==
-            db.HAIPAddressToPortAssociation.ha_ip_address and
-            models_v2.IPAllocation.network_id ==
-            sa.bindparam('network_id'))
+            db.HAIPAddressToPortAssociation.ha_ip_address)
         query += lambda q: q.filter(
             db.HAIPAddressToPortAssociation.port_id ==
-            sa.bindparam('port_id'))
+            sa.bindparam('port_id'),
+            models_v2.IPAllocation.network_id ==
+            sa.bindparam('network_id'))
         return [EndpointOwnedIpInfo._make(row) for row in
                 query(session).params(
                     port_id=port_id,


### PR DESCRIPTION
It would otherwise cause conflicts if multiple projects/VRFs use overlapping subnets with the same allowed_address_pair setup